### PR TITLE
ADR for renaming the project

### DIFF
--- a/docs/rename-package.md
+++ b/docs/rename-package.md
@@ -29,48 +29,48 @@ construction materials":
 - [Joist](https://en.wikipedia.org/wiki/Joist)
 - [Lintel](https://en.wikipedia.org/wiki/Lintel)
 - [Silicone](https://en.wikipedia.org/wiki/Silicone)
+- [Grout](https://en.wikipedia.org/wiki/Grout)
 
 ## Decision
 
-I propose that we rename the project to **Silicone**. This decision is somewhat
-arbitrary; silicone is simply the name that sounds the best to me of the ones
-that I considered, and it's the one that I believe offers the closest allegory
-for the project.
+I propose that we rename the project to **Grout**. Among the options above,
+"Grout" is the name that sounds the best to me, and it's the one that I believe
+offers the closest allegory for the project.
 
-Silicone is a material widely known for its physical flexibility and its
-practical versatility. The [Wikipedia page for
-silicone](https://en.wikipedia.org/wiki/Silicone) lists a wide variety of
-different uses for silicone, ranging from consumer products to
-construction materials.
+Grout is a construction material widely known for its physical flexibility and its
+practical versatility: a fluid concrete used to create waterproof seals in
+masonry structures.
 
-The name "Silicone" respects the origins of Ashlar by making reference to a
-construction material, but unlike "Ashlar", the name "Silicone" emphasizes the
-core features of the project -- its flexibility and versatility as a base material
-with which more complex products can be built.
+Some advantages of the name "Grout" include:
 
-As an added bonus, "the Silicone suite" (as a reference to the multiple tools
-that can be used with the library) is a nice alliteration, as well.
+- "Grout" respects the origins of the project by referencing a masonry material,
+  but unlike "Ashlar", the name "Grout" emphasizes the core features of the project
+  -- its flexibility and versatility as a base material
+  that can scaffold and tie together much more complex projects.
 
-Perhaps most importantly, `silicone` is available on PyPi, and [I'm currently
-squatting on it](https://pypi.org/project/silicone/).
+- "Grout" is one syllable (one fewer than "Ashlar") and the easiest word to
+  pronounce among the options I considered.
+  
+- Perhaps most importantly, `grout` is [available on
+  PyPi](https://pypi.org/project/grout).
 
 ## Status
 
-Currently drafting the ADR. After that, this will be in review.
+In review.
 
 ## Consequences
 
 - After changing the name, we'll have to take a number of steps to update the
   project:
     - Create a new repo for the project
-    - Fork Ashlar and move the code over to Silicone
-    - Update the code to refer to `silicone` instead of `ashlar` internally in
+    - Fork Ashlar and move the code over to Grout 
+    - Update the code to refer to `grout` instead of `ashlar` internally in
     all imports and namespaces
     - Rename repos that reference the name "Ashlar", including;
         - `ashlar-2018-fellowship`
         - `ashlar-blueprint`
 
-- Since "Ashlar" is a more esoteric name than "Silicone", the package may lose SEO.
+- Since "Ashlar" is a more esoteric name than "Grout", the package may lose SEO.
 
 - We'll be able to distribute the project on PyPi with a short and memorable
   name.

--- a/docs/rename-package.md
+++ b/docs/rename-package.md
@@ -1,0 +1,52 @@
+# ADR 2: Choosing a new name for the package
+
+Jean Cochrane (Open Source Fellow, Summer 2018)
+
+## Context
+
+The name Ashlar [is already taken on PyPi](https://pypi.org/project/ashlar/).
+If we want to distribute our package on PyPi, we'll have to either:
+
+1. Convince the owners of `ashlar` to give it to us
+2. Come up with a new name for the project
+
+Option 1 seems unlikely, given the maturity of the ashlar package on PyPi and
+how recent the last release was (April 2018, less than six months ago). Instead,
+I believe that we must choose option 2 and rename the project.
+
+## Decision
+
+I propose that we rename the project to **Silicone**.
+
+Silicone is a material widely known for A) its physical flexibility and B) its
+practical versatility. The [Wikipedia page for
+silicone](https://en.wikipedia.org/wiki/Silicone) lists a wide variety of
+different products made with silicone, ranging from consumer products to
+construction materials.
+
+"Silicone" respects the origins of Ashlar by repurposing a construction material
+for the name of the package, but emphasizes the core feature of the project --
+its flexibility and versatility as a material with which more complex products
+can be built.
+
+The "Silicone suite" (as a reference to the multiple tools that can be used
+with the library) is a nice alliteration, as well.
+
+Perhaps most importantly, `silicone` is available on PyPi, and [I'm currently
+squatting on it](https://pypi.org/project/silicone/).
+
+## Status
+
+Currently drafting the ADR. After that, this will be in review.
+
+## Consequences
+
+After changing the name, we'll have to:
+
+- Create a new repo for the project
+- Fork Ashlar and move the code over to Silicone
+- Update the code to refer to `silicone` instead of `ashlar` internally in
+  all imports and namespaces
+- Rename repos that reference Ashlar, including;
+    - `ashlar-2018-fellowship`
+    - `ashlar-blueprint`

--- a/docs/rename-package.md
+++ b/docs/rename-package.md
@@ -9,17 +9,33 @@ Since PyPi requires unique names for packages, this means that if we want to
 distribute our package on PyPi, we'll have to either:
 
 1. Convince the owners of `ashlar` to give it to us
-2. Come up with a new name for the project
+2. Name the PyPi package something similar to `ashlar` but slightly different,
+   like `ashlar-core`
+3. Come up with a new name for the project
 
 Option 1 seems unlikely, given the maturity of the ashlar package on PyPi and
-how recent the last release was (April 2018, less than six months ago). Instead,
-I believe that the best course of action is to choose option 2 and rename the project.
+how recent the last release was (April 2018, less than four months ago). Number
+2 is perfectly functional but frustrating from a branding and distribution perspective,
+since it has the potential to introduce some confusion and/or competition with
+the existing `ashlar` package.
+
+Instead, I believe that the best course of action is to choose option 3 and rename the project.
 This will require us to come up with a new name for Ashlar, a [notoriously
 difficult decision](https://martinfowler.com/bliki/TwoHardThings.html).
 
+Some options that I considered, all based on the idea of "flexible
+construction materials":
+
+- [Joist](https://en.wikipedia.org/wiki/Joist)
+- [Lintel](https://en.wikipedia.org/wiki/Lintel)
+- [Silicone](https://en.wikipedia.org/wiki/Silicone)
+
 ## Decision
 
-I propose that we rename the project to **Silicone**.
+I propose that we rename the project to **Silicone**. This decision is somewhat
+arbitrary; silicone is simply the name that sounds the best to me of the ones
+that I considered, and it's the one that I believe offers the closest allegory
+for the project.
 
 Silicone is a material widely known for its physical flexibility and its
 practical versatility. The [Wikipedia page for

--- a/docs/rename-package.md
+++ b/docs/rename-package.md
@@ -56,7 +56,7 @@ Some advantages of the name "Grout" include:
 
 ## Status
 
-In review.
+Accepted.
 
 ## Consequences
 

--- a/docs/rename-package.md
+++ b/docs/rename-package.md
@@ -1,36 +1,39 @@
-# ADR 2: Choosing a new name for the package
+# ADR 2: Choosing a new name for Ashlar 
 
 Jean Cochrane (Open Source Fellow, Summer 2018)
 
 ## Context
 
-The name Ashlar [is already taken on PyPi](https://pypi.org/project/ashlar/).
-If we want to distribute our package on PyPi, we'll have to either:
+The name `ashlar` [is already taken on PyPi](https://pypi.org/project/ashlar/).
+Since PyPi requires unique names for packages, this means that if we want to
+distribute our package on PyPi, we'll have to either:
 
 1. Convince the owners of `ashlar` to give it to us
 2. Come up with a new name for the project
 
 Option 1 seems unlikely, given the maturity of the ashlar package on PyPi and
 how recent the last release was (April 2018, less than six months ago). Instead,
-I believe that we must choose option 2 and rename the project.
+I believe that the best course of action is to choose option 2 and rename the project.
+This will require us to come up with a new name for Ashlar, a [notoriously
+difficult decision](https://martinfowler.com/bliki/TwoHardThings.html).
 
 ## Decision
 
 I propose that we rename the project to **Silicone**.
 
-Silicone is a material widely known for A) its physical flexibility and B) its
+Silicone is a material widely known for its physical flexibility and its
 practical versatility. The [Wikipedia page for
 silicone](https://en.wikipedia.org/wiki/Silicone) lists a wide variety of
-different products made with silicone, ranging from consumer products to
+different uses for silicone, ranging from consumer products to
 construction materials.
 
-"Silicone" respects the origins of Ashlar by repurposing a construction material
-for the name of the package, but emphasizes the core feature of the project --
-its flexibility and versatility as a material with which more complex products
-can be built.
+The name "Silicone" respects the origins of Ashlar by making reference to a
+construction material, but unlike "Ashlar", the name "Silicone" emphasizes the
+core features of the project -- its flexibility and versatility as a base material
+with which more complex products can be built.
 
-The "Silicone suite" (as a reference to the multiple tools that can be used
-with the library) is a nice alliteration, as well.
+As an added bonus, "the Silicone suite" (as a reference to the multiple tools
+that can be used with the library) is a nice alliteration, as well.
 
 Perhaps most importantly, `silicone` is available on PyPi, and [I'm currently
 squatting on it](https://pypi.org/project/silicone/).
@@ -41,12 +44,17 @@ Currently drafting the ADR. After that, this will be in review.
 
 ## Consequences
 
-After changing the name, we'll have to:
+- After changing the name, we'll have to take a number of steps to update the
+  project:
+    - Create a new repo for the project
+    - Fork Ashlar and move the code over to Silicone
+    - Update the code to refer to `silicone` instead of `ashlar` internally in
+    all imports and namespaces
+    - Rename repos that reference the name "Ashlar", including;
+        - `ashlar-2018-fellowship`
+        - `ashlar-blueprint`
 
-- Create a new repo for the project
-- Fork Ashlar and move the code over to Silicone
-- Update the code to refer to `silicone` instead of `ashlar` internally in
-  all imports and namespaces
-- Rename repos that reference Ashlar, including;
-    - `ashlar-2018-fellowship`
-    - `ashlar-blueprint`
+- Since "Ashlar" is a more esoteric name than "Silicone", the package may lose SEO.
+
+- We'll be able to distribute the project on PyPi with a short and memorable
+  name.


### PR DESCRIPTION
# Overview

This PR introduces an ADR for renaming the Ashlar project.

## Notes

- Best viewed [on GitHub](https://github.com/azavea/ashlar-2018-fellowship/blob/c1305f5ef4b48a887b50a9020e3875d0e74f2d9c/docs/rename-package.md).

- Choosing names is very hard and I don't expect this decision to be unilateral. Instead, I consider this ADR the start of a conversation around choosing a new name.

Closes #26.
